### PR TITLE
Add function prototypes in examples

### DIFF
--- a/examples/TestFlash/TestFlash.ino
+++ b/examples/TestFlash/TestFlash.ino
@@ -80,6 +80,19 @@ String inputString, outputString;
 
 SPIFlash flash(cs);
 
+void clearprintBuffer();
+bool readSerialStr(String &inputStr);
+void _printPageBytes(uint8_t *data_buffer, uint8_t outputType);
+void printPage(uint16_t page_number, uint8_t outputType);
+void printAllPages(uint8_t outputType);
+void printLine();
+void printSplash();
+void printNextCMD();
+void printOutputChoice();
+void printReadChoice();
+void writeSuccess();
+void writeFail();
+
 void setup() {
   Serial.begin(115200);
   Serial.print(F("Initialising Flash memory"));

--- a/examples/getAddressEx/getAddressEx.ino
+++ b/examples/getAddressEx/getAddressEx.ino
@@ -34,6 +34,9 @@ byte testByte[] = {
 
 SPIFlash flash(CS);
 
+void getAddresses();
+void writeData();
+
 void setup() {
   Serial.begin(115200);
   Serial.print(F("Initialising Flash memory"));

--- a/examples/readWriteString/readWriteString.ino
+++ b/examples/readWriteString/readWriteString.ino
@@ -22,6 +22,8 @@ byte strOffset;
 
 SPIFlash flash(cs);
 
+bool readSerialStr(String &inputStr);
+
 void setup() {
   Serial.begin(115200);
 


### PR DESCRIPTION
To be able to build the examples with [Arduino-Makefile](https://github.com/sudar/Arduino-Makefile) we need proper function prototypes.
Supersedes #20
Fixes #19