### PR TITLE
Adding support for RTL8195A

### DIFF
--- a/SPIFlash.cpp
+++ b/SPIFlash.cpp
@@ -36,12 +36,6 @@ SPIFlash::SPIFlash(uint8_t cs, bool overflow) {
   pageOverflow = overflow;
   pinMode(csPin, OUTPUT);
 }
-#else
-SPIFlash::SPIFlash(uint8_t cs, bool overflow) {
-  csPin = cs;
-  pageOverflow = overflow;
-  pinMode(csPin, OUTPUT);
-}
 #elif defined (BOARD_RTL8195A)
 SPIFlash::SPIFlash(PinName cs, bool overflow) {
   // Adding Low level HAL API to initialize the Chip select pinMode
@@ -52,6 +46,12 @@ SPIFlash::SPIFlash(PinName cs, bool overflow) {
   gpio_mode(&csPin, PullNone);
   gpio_write(&csPin, 1);
   pageOverflow = overflow;
+}
+#else
+SPIFlash::SPIFlash(uint8_t cs, bool overflow) {
+  csPin = cs;
+  pageOverflow = overflow;
+  pinMode(csPin, OUTPUT);
 }
 #endif
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//

--- a/SPIFlash.cpp
+++ b/SPIFlash.cpp
@@ -59,6 +59,17 @@ SPIFlash::SPIFlash(uint8_t cs, bool overflow) {
   pageOverflow = overflow;
   pinMode(csPin, OUTPUT);
 }
+#elif defined (BOARD_RTL8195A)
+SPIFlash::SPIFlash(PinName cs, bool overflow) {
+  // Adding Low level HAL API to initialize the Chip select pinMode
+  // on RTL8195A
+  // @boseji <salearj@hotmail.com> 2nd March 2017
+  gpio_init(&csPin, cs);
+  gpio_dir(&csPin, PIN_OUTPUT);
+  gpio_mode(&csPin, PullNone);
+  gpio_write(&csPin, 1);
+  pageOverflow = overflow;
+}
 #endif
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 //     Private functions used by read, write and erase operations     //

--- a/SPIFlash.h
+++ b/SPIFlash.h
@@ -125,6 +125,7 @@ extern "C" {
     #define CHIP_SELECT   gpio_write(&csPin, 0);
     #define CHIP_DESELECT gpio_write(&csPin, 1);
     #define xfer(n)   SPI.transfer(n)
+    #define BEGIN_SPI SPI.begin();
 #else //#elif defined (ARDUINO_ARCH_ESP8266) || defined (ARDUINO_ARCH_SAMD)
   #define CHIP_SELECT   digitalWrite(csPin, LOW);
   #define CHIP_DESELECT digitalWrite(csPin, HIGH);


### PR DESCRIPTION
Hello,

Your library is an excellent work. It was very helpful.

I had tried to add the RTL8195A Support for your library.
This can be easily used for the Ameba IoT boards.
http://www.amebaiot.com/en/
http://www.amebaiot.com/en/boards/

Hope that you would like to add support for this chip.
I have marked all the changes feel free to modify the architecture if needed.

For testing out the build you can use configuration JSON:
https://github.com/Ameba8195/Arduino/raw/master/release/package_realtek.com_ameba_index.json

If you would like to change any things or need help in integration, 
Please do let me know. 
I wish to return the support as your library has helped me a lot.

Thanking you,

Warm Regards,
Boseji