### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,9 @@ SPIFlash	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 begin	KEYWORD2
-setClock  KEYWORD2
-error KEYWORD2
-libver  KEYWORD2
+setClock	KEYWORD2
+error	KEYWORD2
+libver	KEYWORD2
 getJEDECID	KEYWORD2
 getManID	KEYWORD2
 getAddress	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords